### PR TITLE
Los constructores del estilo antiguo están OBSOLETOS en PHP 7.0

### DIFF
--- a/core/app/action/users-action.php
+++ b/core/app/action/users-action.php
@@ -9,8 +9,8 @@ if(count($_POST)>0){
 	$user->email = $_POST["email"];
 	$user->password = sha1(md5($_POST["password"]));
 	$user->add();
-	Core::alert("Usuario eliminado!");
-	Core::redir("./?view=users");
+	Core::alert("¡Usuario añadido!");
+	Core::redir("./?view=users&o=all");
 }
 }
 else if(isset($_GET["o"]) && $_GET["o"]=="upd"){

--- a/core/app/layouts/layout.php
+++ b/core/app/layouts/layout.php
@@ -43,7 +43,7 @@ Este es el layout principal, a partir de este layout o plantilla se muestran el 
             <li><a href="./?view=home">Mi inicio</a></li>
             <li><a href="./?view=users&o=all">Usuarios</a></li>
             <li class="divider"></li>
-            <li><a href="./?view=access&o=logout">Salir</a></li>
+            <li><a href="./?action=access&o=logout">Salir</a></li>
           </ul>
         </li>
         <?php endif; ?>

--- a/core/app/model/UserData.php
+++ b/core/app/model/UserData.php
@@ -2,7 +2,7 @@
 class UserData {
 	public static $tablename = "user";
 
-	public function Userdata(){
+	public function __construct(){
 		$this->name = "";
 		$this->lastname = "";
 		$this->username = "";

--- a/core/controller/Database.php
+++ b/core/controller/Database.php
@@ -2,7 +2,7 @@
 class Database {
 	public static $db;
 	public static $con;
-	function Database(){
+	function __construct(){
 		$this->user="root";$this->pass="";$this->host="localhost";$this->ddbb="lbmin";
 	}
 

--- a/core/controller/Lb.php
+++ b/core/controller/Lb.php
@@ -7,7 +7,7 @@
 // estoy inspirado : 14/oct/2014 - 0:55am - viendo : un millon de formas de morir en el oeste por 2da vez el dia de hoy
 class Lb {
 
-	public function Lb(){
+	public function __construct(){
 	}
 
 	public function start(){

--- a/core/controller/class.upload.php
+++ b/core/controller/class.upload.php
@@ -2570,7 +2570,7 @@ class upload {
      *    or   string $file Local filename
      * @param  string $lang Optional language code
      */
-    function upload($file, $lang = 'en_GB') {
+    function __construct($file, $lang = 'en_GB') {
 
         $this->version            = '0.32';
 


### PR DESCRIPTION
Los métodos con el mismo nombre que su clase no serán constructores en una versión futura de PHP.

Advertencia

Los constructores del estilo antiguo están OBSOLETOS en PHP 7.0, por lo que serán eliminados en una futura versión. Se debería utilizar siempre __construct() en código nuevo.

http://php.net/manual/es/language.oop5.decon.php